### PR TITLE
Alternative to `ldd` approach

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,15 @@
 FROM --platform=linux/amd64 ubuntu:20.04 as builder
 
-RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y automake libtool clang make cmake
+RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get install -y automake libtool clang make cmake
 
 ADD . /repo
 WORKDIR /repo/Linux
 RUN autoreconf -ivf
-WORKDIR /repo/Linux/build
-RUN cmake ..
-RUN make -j8
-
-RUN mkdir -p /deps
-RUN ldd /repo/Linux/build/src/aescrypt | tr -s '[:blank:]' '\n' | grep '^/' | xargs -I % sh -c 'cp % /deps;'
+RUN mkdir ./dist
+RUN ./configure --prefix=$PWD/dist
+RUN make install 
 
 FROM ubuntu:20.04 as package
 
-COPY --from=builder /deps /deps
-COPY --from=builder /repo/Linux/build/src/aescrypt /repo/Linux/build/src/aescrypt
-ENV LD_LIBRARY_PATH=/deps
+RUN mkdir /aescrypt
+COPY --from=builder /repo/Linux/dist /aescrypt

--- a/Mayhemfile
+++ b/Mayhemfile
@@ -2,4 +2,4 @@ project: aescrypt
 target: aescrypt
 
 cmds:
-  - cmd: /repo/Linux/build/src/aescrypt -e -p password @@
+  - cmd: /aescrypt/aescrypt -e -p password @@

--- a/Mayhemfile
+++ b/Mayhemfile
@@ -2,4 +2,4 @@ project: aescrypt
 target: aescrypt
 
 cmds:
-  - cmd: /aescrypt/aescrypt -e -p password @@
+  - cmd: /aescrypt/bin/aescrypt -e -p password @@


### PR DESCRIPTION
It looks like a number of submissions are using autotools to build. For submissions with this build system, you can specify a build prefix where all of the necessary libraries can be stored. For `aescrypt`, it actually doesn't require any of these dependencies, so I didn't need to change anything in the package stage. Still, this may be a path forward for projects using autotools. 